### PR TITLE
Change initial conditions for salinity and temperature in `TwoLayerDNS` and add `save_schedule` for output saving

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
 SeawaterPolynomials = "d496a93d-167e-4197-9f49-d3af4ff8fe40"
+SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 GibbsSeaWater = "0.1"

--- a/examples/high_resolution.jl
+++ b/examples/high_resolution.jl
@@ -5,7 +5,6 @@ using DirectNumericalCabbelingShenanigans.TwoLayerDNS
 architecture = CPU()
 diffusivities = (ν = 1e-4, κ = (S = 1e-6, T = 1e-5))
 resolution = (Nx = 20, Ny = 20, Nz = 4000)
-reference_density = gsw_rho(S₀ˡ, T₀ˡ, 0)
 
 ## Setup the model
 model = DNS(architecture, domain_extent, resolution, diffusivities; reference_density)

--- a/examples/high_resolution.jl
+++ b/examples/high_resolution.jl
@@ -17,16 +17,13 @@ cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ.cabbeling, T₀ᵘ)
 unstable = UnstableUpperLayerInitialConditions(S₀ᵘ.unstable, T₀ᵘ)
 isohaline = IsohalineUpperLayerInitialConditions(T₀ᵘ)
 initial_conditions = TwoLayerInitialConditions(isohaline)
-set_two_layer_initial_conditions!(model, initial_conditions;
-                                  perturb_salinity = false,
-                                  interface_location = 0.375, interface_thickness = 10000,
-                                  salinity_perturbation_width = 100)
-DNCS.OutputUtilities.visualise_initial_conditions(model)
-DNCS.OutputUtilities.visualise_initial_density(model, 0)
+set_two_layer_initial_conditions!(model, initial_conditions, interface_location)
+
 ## build the simulation
 Δt = 1e-4
 stop_time = 2
-simulation = DNS_simulation_setup(model, Δt, stop_time, initial_conditions)
+save_schedule = 0.5 # seconds
+simulation = DNS_simulation_setup(model, Δt, stop_time, save_schedule, initial_conditions)
 
 ## Run the simulation
 run!(simulation)

--- a/examples/high_resolution_gpu.jl
+++ b/examples/high_resolution_gpu.jl
@@ -5,7 +5,6 @@ using DirectNumericalCabbelingShenanigans.TwoLayerDNS
 architecture = GPU()
 diffusivities = (ν = 1e-4, κ = (S = 1e-6, T = 1e-5))
 resolution = (Nx = 20, Ny = 20, Nz = 4000)
-reference_density = gsw_rho(S₀ˡ, T₀ˡ, 0)
 
 ## Setup the model
 model = DNS(architecture, domain_extent, resolution, diffusivities; reference_density)

--- a/examples/high_resolution_gpu.jl
+++ b/examples/high_resolution_gpu.jl
@@ -17,15 +17,13 @@ cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ.cabbeling, T₀ᵘ)
 unstable = UnstableUpperLayerInitialConditions(S₀ᵘ.unstable, T₀ᵘ)
 isohaline = IsohalineUpperLayerInitialConditions(T₀ᵘ)
 initial_conditions = TwoLayerInitialConditions(isohaline)
-set_two_layer_initial_conditions!(model, initial_conditions;
-                                  perturb_salinity = false,
-                                  interface_location = 0.375, interface_thickness = 100,
-                                  salinity_perturbation_width = 100)
+set_two_layer_initial_conditions!(model, initial_conditions, interface_location)
 
 ## build the simulation
 Δt = 1e-5
 stop_time = 10
-simulation = DNS_simulation_setup(model, Δt, stop_time, initial_conditions)
+save_schedule = 0.5 # seconds
+simulation = DNS_simulation_setup(model, Δt, stop_time, save_schedule, initial_conditions)
 
 ## Run the simulation
 run!(simulation)

--- a/examples/medium_resolution.jl
+++ b/examples/medium_resolution.jl
@@ -5,7 +5,6 @@ using DirectNumericalCabbelingShenanigans.TwoLayerDNS
 architecture = CPU() # or GPU()
 diffusivities = (ν = 1e-4, κ = (S = 1e-6, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 1000)
-reference_density = gsw_rho(S₀ˡ, T₀ˡ, 0)
 
 ## Setup the model
 model = DNS(architecture, domain_extent, resolution, diffusivities; reference_density)
@@ -18,9 +17,8 @@ cabbeling = CabbelingUpperLayerInitialConditions(S₀ᵘ.cabbeling, T₀ᵘ)
 unstable = UnstableUpperLayerInitialConditions(S₀ᵘ.unstable, T₀ᵘ)
 isohaline = IsohalineUpperLayerInitialConditions(T₀ᵘ)
 initial_conditions = TwoLayerInitialConditions(unstable)
-set_two_layer_initial_conditions!(model, initial_conditions;
-                                  interface_location = 0.375, interface_thickness = 100,
-                                  salinity_perturbation_width = 100)
+interface_location = -0.375
+set_two_layer_initial_conditions!(model, initial_conditions, interface_location)
 
 ## build the simulation
 Δt = 1e-4

--- a/examples/medium_resolution.jl
+++ b/examples/medium_resolution.jl
@@ -3,7 +3,7 @@ using DirectNumericalCabbelingShenanigans
 using DirectNumericalCabbelingShenanigans.TwoLayerDNS
 
 architecture = CPU() # or GPU()
-diffusivities = (ν = 1e-4, κ = (S = 1e-6, T = 1e-5))
+diffusivities = (ν = 1e-4, κ = (S = 1e-5, T = 1e-5))
 resolution = (Nx = 10, Ny = 10, Nz = 1000)
 
 ## Setup the model

--- a/examples/medium_resolution.jl
+++ b/examples/medium_resolution.jl
@@ -23,7 +23,8 @@ set_two_layer_initial_conditions!(model, initial_conditions, interface_location)
 ## build the simulation
 Δt = 1e-4
 stop_time = 1
-simulation = DNS_simulation_setup(model, Δt, stop_time, initial_conditions)
+save_schedule = 0.5 # seconds
+simulation = DNS_simulation_setup(model, Δt, stop_time, save_schedule, initial_conditions)
 
 ## Run the simulation
 run!(simulation)

--- a/src/DNS.jl
+++ b/src/DNS.jl
@@ -90,7 +90,9 @@ Setup the simulation for `DNS` model.
 - `Δt` timestep. A timestep wizard is also setup so the size of the timestep may change over
 the course of a simulation;
 - `stop_time` length of simulation time (in seconds) to run the model for;
-- `savefile` name of the file to save the data to.
+- `savefile` name of the file to save the data to,
+- `save_schedule` number (representing time in seconds) at which to save model output, e.g.,
+`save_schedule = 1` saves output every second.
 
 ## Keyword arguments:
 
@@ -100,7 +102,8 @@ the course of a simulation;
 - `max_Δt` the maximum timestep.
 """
 function DNS_simulation_setup(model::Oceananigans.AbstractModel, Δt::Number,
-                              stop_time::Number, savefile::AbstractString;
+                              stop_time::Number, savefile::AbstractString,
+                              save_schedule::Number;
                               cfl = 0.75,
                               diffusive_cfl = 0.75,
                               max_change = 1.2,
@@ -121,7 +124,7 @@ function DNS_simulation_setup(model::Oceananigans.AbstractModel, Δt::Number,
     filename = joinpath(SIMULATION_PATH, savefile * ".jld2")
     simulation.output_writers[:outputs] = JLD2OutputWriter(model, outputs,
                                                     filename = filename,
-                                                    schedule = IterationInterval(50),
+                                                    schedule = TimeInterval(save_schedule),
                                                     overwrite_existing = true)
 
     # progress reporting

--- a/src/output_utils.jl
+++ b/src/output_utils.jl
@@ -5,6 +5,7 @@ Module to help process and analyse output data from running a Direct Numerical S
 module OutputUtilities
 
 using DirectNumericalCabbelingShenanigans, Printf
+using DirectNumericalCabbelingShenanigans.TwoLayerDNS: TwoLayerInitialConditions
 using Oceananigans.Fields
 
 @reexport using CairoMakie, JLD2, GibbsSeaWater
@@ -12,6 +13,7 @@ using Oceananigans.Fields
 export
     animate_2D_field,
     visualise_initial_conditions,
+    visualise_initial_stepchange,
     visualise_initial_density,
     visualise_snapshot,
     compute_density
@@ -60,7 +62,74 @@ function animate_2D_field(field_timeseries::FieldTimeSeries, field_name::Abstrac
     end
 
 end
+"""
+    function visualise_initial_stepchange(model::Oceananigans.AbstractModel,
+                                          initial_conditions::TwoLayereInitialConditions,
+                                          interface_location::Number)
+Plot an initial step change of the `tracers` in a `model`. This function assumes there are two
+tracers (salinity and temperature) and plots the x-z, y-z and field-z initial fields.
+"""
+function visualise_initial_stepchange(model::Oceananigans.AbstractModel,
+                                      initial_conditions::TwoLayerInitialConditions,
+                                      interface_location::Number)
 
+    x, y, z = nodes(model.grid, (Center(), Center(), Center()))
+    S₀ˡ, ΔS₀ = initial_conditions.S₀ˡ, initial_conditions.ΔS₀
+    T₀ˡ, ΔT₀ = initial_conditions.T₀ˡ, initial_conditions.ΔT₀
+    S_stepchange = initial_tracer_heaviside.(z, S₀ˡ, ΔS₀, interface_location)
+    S_sc_array = repeat(S_stepchange', length(x), 1)
+    T_stepchange = initial_tracer_heaviside.(z, T₀ˡ, ΔT₀, interface_location)
+    T_sc_array = repeat(T_stepchange', length(x), 1)
+    fig = Figure(size = (600, 1500))
+    ax = [Axis(fig[j, i]) for i ∈ 1:2, j ∈ 1:3]
+
+    hm = heatmap!(ax[1], x, z, S_sc_array; colormap = :haline)
+    ax[1].title = "Initial salinity (x-z)"
+    ax[1].xlabel = "x (m)"
+    ax[1].ylabel = "z (m)"
+    heatmap!(ax[2], x, z, S_sc_array; colormap = :haline)
+    ax[2].title = "Initial salinity (y-z)"
+    ax[2].xlabel = "y (m)"
+    ax[2].ylabel = "z (m)"
+    Colorbar(fig[1, 3], hm, label = "S (gkg⁻¹)")
+    hm = heatmap!(ax[3], y, z, T_sc_array; colormap = :thermal)
+    ax[3].title = "Initial temperature (x-z)"
+    ax[3].xlabel = "x (m)"
+    ax[3].ylabel = "z (m)"
+    heatmap!(ax[4], y, z, T_sc_array; colormap = :thermal)
+    ax[4].title = "Initial temperature (y-z)"
+    ax[4].xlabel = "y (m)"
+    ax[4].ylabel = "z (m)"
+    Colorbar(fig[2, 3], hm, label = "Θ (°C)")
+    lines!(ax[5], S_stepchange, z)
+    ax[5].title = "Initial salinity profile"
+    ax[5].xlabel = "S (gkg⁻¹)"
+    ax[5].ylabel = "z (m)"
+    lines!(ax[6], T_stepchange, z)
+    ax[6].title = "Initial temperature profile"
+    ax[6].xlabel =  "Θ (°C)"
+    ax[6].ylabel = "z (m)"
+
+    return fig
+
+end
+"""
+    initial_tracer_heaviside(z, C::Number, ΔC::Number, interface_location)
+Modified Heaviside function for initial condition of a tracer with depth. The interface_location of the
+Heaviside function is calculated from the `extrema` of the depth array `z`.
+
+## Function arguments:
+
+- `z` for the Oceananigans model grid to evaulate the function at;
+- `C` tracer value in deeper part of the step;
+- `ΔC` difference in tracer between the steps.
+
+## Keyword arguments:
+- `interface_location` where the step takes place e.g. `z - interface_location < 0 ? 0 : 1`.
+Default behaviour puts the `interface_location` in the centre of the depth range given by `z`.
+"""
+initial_tracer_heaviside(z, C::Number, ΔC::Number, interface_location) =
+                                                    z - interface_location < 0 ? C : C + ΔC
 """
     function visualise_initial_conditions(model::Oceanangians.AbstractModel)
 Plot the initial state of the `tracers` in a `model`. This function assumes there are two

--- a/src/output_utils.jl
+++ b/src/output_utils.jl
@@ -54,7 +54,7 @@ function animate_2D_field(field_timeseries::FieldTimeSeries, field_name::Abstrac
     frames = eachindex(t)
     filename = string(field_dimensions[1]) * string(field_dimensions[2]) * "_" *
                 field_name
-    record(fig, joinpath(@__DIR__, "../data/analysis/", filename * ".mp4"),
+    record(fig, joinpath(pwd(), "/data/analysis/", filename * ".mp4"),
           frames, framerate=8) do i
         msg = string("Plotting frame ", i, " of ", frames[end])
         print(msg * " \r")

--- a/src/twolayersetup.jl
+++ b/src/twolayersetup.jl
@@ -233,7 +233,7 @@ upper layer. This is what creates the instability to cause mixing.
 """
 function set_two_layer_initial_conditions!(model::Oceananigans.AbstractModel,
                                            initial_conditions::TwoLayerInitialConditions,
-                                           interface_location::Number,
+                                           interface_location::Number;
                                            t = 10,
                                            perturb_salinity = false,
                                            salinity_perturbation_width = 100)
@@ -323,7 +323,7 @@ Important non-dimensional numnbers that are part of this experiment are computed
 to the simulation output file.
 """
 function DNCS.DNS_simulation_setup(model::Oceananigans.AbstractModel, Δt::Number,
-                                   stop_time::Number,
+                                   stop_time::Number, save_schedule::Number,
                                    initial_conditions::TwoLayerInitialConditions;
                                    cfl = 0.75,
                                    diffusive_cfl = 0.75,
@@ -341,14 +341,14 @@ function DNCS.DNS_simulation_setup(model::Oceananigans.AbstractModel, Δt::Numbe
     filename = form_filename(initial_conditions)
     simulation.output_writers[:outputs] = JLD2OutputWriter(model, outputs,
                                                     filename = filename,
-                                                    schedule = IterationInterval(50),
+                                                    schedule = TimeInterval(save_schedule),
                                                     overwrite_existing = true)
     jldopen(filename, "a+") do file
         file["Non_dimensional_numbers"] = non_dimensional_numbers(model, initial_conditions)
     end
 
     # progress reporting
-    simulation.callbacks[:progress] = Callback(simulation_progress, IterationInterval(50))
+    simulation.callbacks[:progress] = Callback(simulation_progress, IterationInterval(100))
 
     return simulation
 


### PR DESCRIPTION
Previously the initial conditions for the `TwoLayerDNS` module were a hyperbolic tangent. They have now been changed to a solution to the heat equation at time $t$ subject to initial conditions that are a step change. This makes the setting of the initial conditions much less arbitrary as we can set a step change but then use the solution to the heat equation to emulate mixing for some amount of time to then get initial conditions for the DNS.

There is also a plotting function added to visualise what an initial step change looks like and a constant `reference_density` exported by the module based on the salinity and temperature of the lower layer (though this might cause issues if we change what reference density we are using).