### PR TITLE
Add random noise function for initial conditions

### DIFF
--- a/src/twolayersetup.jl
+++ b/src/twolayersetup.jl
@@ -20,6 +20,7 @@ export
     UnstableTwoLayerInitialConditions,
     IsohalineTwoLayerInitialConditions,
     set_two_layer_initial_conditions!,
+    horiztonal_random_noise!,
     S₀ˡ, T₀ˡ,
     domain_extent,
     high_resolution,
@@ -291,6 +292,28 @@ function set_two_layer_initial_conditions!(model::Oceananigans.AbstractModel,
     set!(model, S = initial_S_profile, T = initial_T_profile)
 
 return nothing
+
+end
+"""
+    function horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
+                                    interface_location::Number)
+Add standard normally distributed random noise, scaled by `noise_magnitude`, to the
+horizontal velocity fields at the interface of the upper and lower layers.
+"""
+function horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
+                                  interface_location::Number)
+
+    u, v, w = model.velocities
+    uᵢ, vᵢ = zeros(size(u)), zeros(size(v))
+    u_noise = noise_magnitude * randn(size(u)[1:2])
+    v_noise = noise_magnitude * randn(size(u)[1:2])
+    interface_index = findall(znodes(model.grid, Face()) .== interface_location)[1]
+    uᵢ[:, :, interface_index] += u_noise
+    vᵢ[:, :, interface_index] += v_noise
+
+    set!(model, u = uᵢ, v = vᵢ)
+
+    return nothing
 
 end
 """

--- a/src/twolayersetup.jl
+++ b/src/twolayersetup.jl
@@ -20,7 +20,7 @@ export
     UnstableTwoLayerInitialConditions,
     IsohalineTwoLayerInitialConditions,
     set_two_layer_initial_conditions!,
-    horiztonal_random_noise!,
+    add_horiztonal_random_noise!,
     S₀ˡ, T₀ˡ,
     domain_extent,
     high_resolution,
@@ -300,7 +300,7 @@ end
 Add standard normally distributed random noise, scaled by `noise_magnitude`, to the
 horizontal velocity fields at the interface of the upper and lower layers.
 """
-function horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
+function add_horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
                                   interface_location::Number)
 
     u, v, w = model.velocities

--- a/src/twolayersetup.jl
+++ b/src/twolayersetup.jl
@@ -20,7 +20,7 @@ export
     UnstableTwoLayerInitialConditions,
     IsohalineTwoLayerInitialConditions,
     set_two_layer_initial_conditions!,
-    add_horiztonal_random_noise!,
+    add_horizontal_random_noise!,
     S₀ˡ, T₀ˡ,
     domain_extent,
     high_resolution,
@@ -295,23 +295,18 @@ return nothing
 
 end
 """
-    function horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
-                                    interface_location::Number)
+    function add_horizontal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
+                                          interface_location::Number)
 Add standard normally distributed random noise, scaled by `noise_magnitude`, to the
 horizontal velocity fields at the interface of the upper and lower layers.
 """
-function add_horiztonal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
-                                  interface_location::Number)
+function add_horizontal_random_noise!(model::Oceananigans.AbstractModel, noise_magnitude::Number,
+                                      interface_location::Number)
 
-    u, v, w = model.velocities
-    uᵢ, vᵢ = zeros(size(u)), zeros(size(v))
-    u_noise = noise_magnitude * randn(size(u)[1:2])
-    v_noise = noise_magnitude * randn(size(u)[1:2])
-    interface_index = findall(znodes(model.grid, Face()) .== interface_location)[1]
-    uᵢ[:, :, interface_index] += u_noise
-    vᵢ[:, :, interface_index] += v_noise
+    add_noise(x, y, z) = round(z; digits = 3) == interface_location ?
+                                                 noise_magnitude * randn() : 0
 
-    set!(model, u = uᵢ, v = vᵢ)
+    set!(model, u = add_noise, v = add_noise)
 
     return nothing
 


### PR DESCRIPTION
Add a function to add small amount of random noise about the interface of the two layers of a simulation. Previously when I tried this at very high resolution it blew up but this function will make it easier to try (if needed) later on. According to [Oceananigans.jl documentation](https://clima.github.io/OceananigansDocumentation/dev/model_setup/setting_initial_conditions/) the velocity field is made to be divergence free so I think (though am not sure) this is why the velocity is not zero everywhere and only random noise at the interface.