### PR TITLE
Add `compute_density!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DirectNumericalCabbelingShenanigans"
 uuid = "40aaee9f-3595-48be-b36c-f1067009652f"
 authors = ["Josef Bisits <jbisits@gmail.com>"]
-version = "0.3.5"
+version = "0.3.6"
 
 [deps]
 CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"

--- a/examples/simulationoutput.jl
+++ b/examples/simulationoutput.jl
@@ -5,8 +5,8 @@ using DirectNumericalCabbelingShenanigans.OutputUtilities
 
 ## Load in saved output
 sim_path = joinpath(SIMULATION_PATH, "saved_output.jld2")
-T_ts = FieldTimeSeries(sim_path, "T")
-S_ts = FieldTimeSeries(sim_path, "S")
+T_ts = FieldTimeSeries(sim_path, "T", backend = OnDisk())
+S_ts = FieldTimeSeries(sim_path, "S", backend = OnDisk())
 
 ## Initial snapshots
 visualise_snapshot(T_ts, "Θ (°C)", 1, 1, 1)

--- a/src/output_utils.jl
+++ b/src/output_utils.jl
@@ -271,7 +271,10 @@ passed to specify a reference pressure at which to compute the density variable.
 function compute_density(S_timeseries::FieldTimeSeries, T_timeseries::FieldTimeSeries;
                          reference_pressure = 0)
 
-    ρ_ts = deepcopy(S_timeseries)
+    ρ_ts = FieldTimeSeries{Center, Center, Center}(S_timeseries.grid, S_timeseries.times,
+                                                  indices = S_timeseries.indices,
+                                                  boundary_conditions =
+                                                    S_timeseries.boundary_conditions)
     t = S_timeseries.times
     for i ∈ eachindex(t)
         Sᵢ, Θᵢ = S_timeseries[i], T_timeseries[i]

--- a/src/output_utils.jl
+++ b/src/output_utils.jl
@@ -16,7 +16,8 @@ export
     visualise_initial_stepchange,
     visualise_initial_density,
     visualise_snapshot,
-    compute_density
+    compute_density,
+    compute_density!
 
 """
     function animate_2D_field(field_timeseries::FieldTimeSeries, field_name::AbstractString,
@@ -275,6 +276,7 @@ function compute_density(S_timeseries::FieldTimeSeries, T_timeseries::FieldTimeS
                                                   indices = S_timeseries.indices,
                                                   boundary_conditions =
                                                     S_timeseries.boundary_conditions)
+
     t = S_timeseries.times
     for i ∈ eachindex(t)
         Sᵢ, Θᵢ = S_timeseries[i], T_timeseries[i]
@@ -284,5 +286,35 @@ function compute_density(S_timeseries::FieldTimeSeries, T_timeseries::FieldTimeS
     return ρ_ts
 
 end
+"""
+    function compute_density!(filepath::String; reference_pressure = 0)
+Compute a density variable at `reference_pressure` and append it to saved output. **Note**
+this only needs to be done once! After that the group will exist and will not be able to be
+overwritten but a different group can be made by passing a different `density_string`.
+This allows calling `FieldTimeSeries` on the `density_variable`
+"""
+function compute_density!(filepath::String; reference_pressure = 0, density_string = "ρ")
 
+    file = jldopen(filepath, "a+")
+    file_keys = keys(file["timeseries"]["S"])
+    JLD2.Group(file, "timeseries/"*density_string)
+    for (i, key) ∈ enumerate(file_keys)
+        if i == 1
+            for k ∈ keys(file["timeseries/S/"*key])
+                file["timeseries/"*density_string*"/"*key*"/"*k] =
+                    file["timeseries/S/"*key*"/"*k]
+            end
+            file["timeseries/"*density_string*"/"*key*"/reference_pressure"] =
+                reference_pressure
+        else
+            Sᵢ, Θᵢ = file["timeseries/S/"*key], file["timeseries/T/"*key]
+            file["timeseries/"*density_string*"/"*key]= gsw_rho.(Sᵢ, Θᵢ, reference_pressure)
+        end
+    end
+
+    close(file)
+
+    return nothing
+
+end
 end # module


### PR DESCRIPTION
This function computes the same density variable as `compute_density` but appends it to the saved data so it can be correctly read in by `FieldTimeSeries` using `backend = OnDisk()`.

Closes #55 