### PR TITLE
Add `linear_eos` option for `DNS`

### DIFF
--- a/src/DirectNumericalCabbelingShenanigans.jl
+++ b/src/DirectNumericalCabbelingShenanigans.jl
@@ -1,6 +1,7 @@
 module DirectNumericalCabbelingShenanigans
 
-using Oceananigans, SeawaterPolynomials, Printf, Reexport
+using Oceananigans, Printf, Reexport
+using SeawaterPolynomials: TEOS10EquationOfState
 using Oceananigans: AbstractModel
 
 @reexport using Oceananigans, Reexport


### PR DESCRIPTION
Also able to specify thermal expansion and haline contraction coefficients, the defaults are the same as that used by [Oceananigans.jl](https://clima.github.io/OceananigansDocumentation/dev/appendix/library/#Oceananigans.BuoyancyModels.LinearEquationOfState).

Closes #63 